### PR TITLE
Add support for normalizing the archived files metadata

### DIFF
--- a/archive/archiver.go
+++ b/archive/archiver.go
@@ -6,10 +6,10 @@ import (
 )
 
 type Archiver interface {
-	ArchiveContent(content []byte, infilename string) error
-	ArchiveFile(infilename string) error
-	ArchiveDir(indirname string, excludes []string) error
-	ArchiveMultiple(content map[string][]byte) error
+	ArchiveContent(content []byte, infilename string, normalizeFilesMetadata bool) error
+	ArchiveFile(infilename string, normalizeFilesMetadata bool) error
+	ArchiveDir(indirname string, excludes []string, normalizeFilesMetadata bool) error
+	ArchiveMultiple(content map[string][]byte, normalizeFilesMetadata bool) error
 }
 
 type ArchiverBuilder func(filepath string) Archiver

--- a/archive/zip_archiver_test.go
+++ b/archive/zip_archiver_test.go
@@ -16,7 +16,7 @@ import (
 func TestZipArchiver_Content(t *testing.T) {
 	zipfilepath := "archive-content.zip"
 	archiver := NewZipArchiver(zipfilepath)
-	if err := archiver.ArchiveContent([]byte("This is some content"), "content.txt"); err != nil {
+	if err := archiver.ArchiveContent([]byte("This is some content"), "content.txt", false); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -25,10 +25,20 @@ func TestZipArchiver_Content(t *testing.T) {
 	})
 }
 
+func TestZipArchiver_Content_WithNormalizedFilesMetadata(t *testing.T) {
+	zipfilepath := "archive-content.zip"
+	archiver := NewZipArchiver(zipfilepath)
+	if err := archiver.ArchiveContent([]byte("This is some content"), "content.txt", true); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ensureFileChecksum(t, zipfilepath, "952e89afb0435cd5e01e3e4cdf22c5b0")
+}
+
 func TestZipArchiver_File(t *testing.T) {
 	zipfilepath := "archive-file.zip"
 	archiver := NewZipArchiver(zipfilepath)
-	if err := archiver.ArchiveFile("./test-fixtures/test-file.txt"); err != nil {
+	if err := archiver.ArchiveFile("./test-fixtures/test-file.txt", false); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -45,7 +55,7 @@ func TestZipArchiver_FileModified(t *testing.T) {
 
 	var zip = func() {
 		archiver := NewZipArchiver(zipFilePath)
-		if err := archiver.ArchiveFile(toZipPath); err != nil {
+		if err := archiver.ArchiveFile(toZipPath, false); err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	}
@@ -75,10 +85,20 @@ func TestZipArchiver_FileModified(t *testing.T) {
 	}
 }
 
+func TestZipArchiver_File_WithNormalizedFilesMetadata(t *testing.T) {
+	zipfilepath := "archive-file.zip"
+	archiver := NewZipArchiver(zipfilepath)
+	if err := archiver.ArchiveFile("./test-fixtures/test-file.txt", true); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ensureFileChecksum(t, zipfilepath, "86f7cb871bc437b8174fca96bf7a464f")
+}
+
 func TestZipArchiver_Dir(t *testing.T) {
 	zipfilepath := "archive-dir.zip"
 	archiver := NewZipArchiver(zipfilepath)
-	if err := archiver.ArchiveDir("./test-fixtures/test-dir", []string{""}); err != nil {
+	if err := archiver.ArchiveDir("./test-fixtures/test-dir", []string{""}, false); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -92,7 +112,7 @@ func TestZipArchiver_Dir(t *testing.T) {
 func TestZipArchiver_Dir_Exclude(t *testing.T) {
 	zipfilepath := "archive-dir.zip"
 	archiver := NewZipArchiver(zipfilepath)
-	if err := archiver.ArchiveDir("./test-fixtures/test-dir", []string{"file2.txt"}); err != nil {
+	if err := archiver.ArchiveDir("./test-fixtures/test-dir", []string{"file2.txt"}, false); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -105,7 +125,7 @@ func TestZipArchiver_Dir_Exclude(t *testing.T) {
 func TestZipArchiver_Dir_Exclude_With_Directory(t *testing.T) {
 	zipfilepath := "archive-dir.zip"
 	archiver := NewZipArchiver(zipfilepath)
-	if err := archiver.ArchiveDir("./test-fixtures/", []string{"test-dir", "test-dir2/file2.txt"}); err != nil {
+	if err := archiver.ArchiveDir("./test-fixtures/", []string{"test-dir", "test-dir2/file2.txt"}, false); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -114,6 +134,16 @@ func TestZipArchiver_Dir_Exclude_With_Directory(t *testing.T) {
 		"test-dir2/file3.txt": []byte("This is file 3"),
 		"test-file.txt":       []byte("This is test content"),
 	})
+}
+
+func TestZipArchiver_Dir_WithNormalizedFilesMetadata(t *testing.T) {
+	zipfilepath := "archive-dir.zip"
+	archiver := NewZipArchiver(zipfilepath)
+	if err := archiver.ArchiveDir("./test-fixtures/test-dir", []string{""}, true); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ensureFileChecksum(t, zipfilepath, "dfb9a8da8c73034f51a5c3c5d822e64b")
 }
 
 func TestZipArchiver_Multiple(t *testing.T) {
@@ -125,12 +155,28 @@ func TestZipArchiver_Multiple(t *testing.T) {
 	}
 
 	archiver := NewZipArchiver(zipfilepath)
-	if err := archiver.ArchiveMultiple(content); err != nil {
+	if err := archiver.ArchiveMultiple(content, false); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
 	ensureContents(t, zipfilepath, content)
 
+}
+
+func TestZipArchiver_Multiple_WithNormalizedFilesMetadata(t *testing.T) {
+	zipfilepath := "archive-content.zip"
+	content := map[string][]byte{
+		"file1.txt": []byte("This is file 1"),
+		"file2.txt": []byte("This is file 2"),
+		"file3.txt": []byte("This is file 3"),
+	}
+
+	archiver := NewZipArchiver(zipfilepath)
+	if err := archiver.ArchiveMultiple(content, true); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ensureFileChecksum(t, zipfilepath, "dfb9a8da8c73034f51a5c3c5d822e64b")
 }
 
 func ensureContents(t *testing.T, zipfilepath string, wants map[string][]byte) {


### PR DESCRIPTION
When archiving files from different machines, even if the source content is the same, different archive files may be generated due to a variety of factors, like compression libraries or file metadata difference (permissions, etc.).

This creates problems in situations where it's expected that the exact same archive should always be generated from a given source content (typically, a Lambda function resource).

An example context that causes differences is Git on different O/Ss - filesystems may have different mount permission masks, and be the same for Git (which doesn't distinguish 0644 from 0664), but end up generating a different archive.

The `normalize_files_metadata` option makes the archiver produce a "normalized" archive, which solves the problem. In the Zip case, this is obtained by setting:

- the compression method to Store
- the modification date to a fixed one
- the permissions to 0644

Disabling compression is a tradeoff, however, in the context where this functionality is used (eg. Lambda function resources), the difference is negligible.